### PR TITLE
refactor design/apidsl/response_test.go

### DIFF
--- a/design/apidsl/response_test.go
+++ b/design/apidsl/response_test.go
@@ -1,200 +1,212 @@
 package apidsl_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	"testing"
+
 	"github.com/shogo82148/shogoa/design"
 	"github.com/shogo82148/shogoa/design/apidsl"
 	"github.com/shogo82148/shogoa/dslengine"
 )
 
-var _ = Describe("Response", func() {
-	var name string
-	var dt design.DataType
-	var dsl func()
-
-	var res *design.ResponseDefinition
-
-	BeforeEach(func() {
+func TestResponse(t *testing.T) {
+	t.Run("with no dsl and no name", func(t *testing.T) {
 		dslengine.Reset()
-		name = ""
-		dsl = nil
-		dt = nil
-	})
-
-	JustBeforeEach(func() {
 		apidsl.Resource("res", func() {
 			apidsl.Action("action", func() {
-				if dt != nil {
-					apidsl.Response(name, dt, dsl)
-				} else {
-					apidsl.Response(name, dsl)
-				}
+				apidsl.Response("")
 			})
 		})
-		dslengine.Run()
-		if r, ok := design.Design.Resources["res"]; ok {
-			if a, ok := r.Actions["action"]; ok {
-				res = a.Responses[name]
-			}
+		_ = dslengine.Run()
+
+		res := design.Design.Resources["res"].Actions["action"].Responses[""]
+		if err := res.Validate(); err == nil {
+			t.Error("Validate() = nil; want an error")
 		}
 	})
 
-	Context("with no dsl and no name", func() {
-		It("produces an invalid action definition", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Validate()).Should(HaveOccurred())
+	t.Run("with no dsl", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("foo")
+			})
 		})
+		_ = dslengine.Run()
+
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if err := res.Validate(); err == nil {
+			t.Error("Validate() = nil; want an error")
+		}
 	})
 
-	Context("with no dsl", func() {
-		BeforeEach(func() {
-			name = "foo"
-		})
-
-		It("produces an invalid action definition", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Validate()).Should(HaveOccurred())
-		})
-	})
-
-	Context("with a status", func() {
-		const status = 201
-
-		BeforeEach(func() {
-			name = "foo"
-			dsl = func() {
-				apidsl.Status(status)
-			}
-		})
-
-		It("produces a valid action definition and sets the status and parent", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Validate()).ShouldNot(HaveOccurred())
-			Ω(res.Status).Should(Equal(status))
-			Ω(res.Parent).ShouldNot(BeNil())
-		})
-	})
-
-	Context("with a type override", func() {
-		const status = 201
-
-		BeforeEach(func() {
-			name = "foo"
-			dsl = func() {
-				apidsl.Status(status)
-			}
-			dt = apidsl.HashOf(design.String, design.Any)
-		})
-
-		It("produces a response definition with the given type", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Type).Should(Equal(dt))
-			Ω(res.Validate()).ShouldNot(HaveOccurred())
-		})
-	})
-
-	Context("with a status and description", func() {
-		const status = 201
-		const description = "desc"
-
-		BeforeEach(func() {
-			name = "foo"
-			dsl = func() {
-				apidsl.Status(status)
-				apidsl.Description(description)
-			}
-		})
-
-		It("sets the status and description", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Validate()).ShouldNot(HaveOccurred())
-			Ω(res.Status).Should(Equal(status))
-			Ω(res.Description).Should(Equal(description))
-		})
-	})
-
-	Context("with a status and name override", func() {
-		const status = 201
-
-		BeforeEach(func() {
-			name = "foo"
-			dsl = func() {
-				apidsl.Status(status)
-			}
-		})
-
-		It("sets the status and name", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Validate()).ShouldNot(HaveOccurred())
-			Ω(res.Status).Should(Equal(status))
-		})
-	})
-
-	Context("with a status and media type", func() {
-		const status = 201
-		const mediaType = "mt"
-
-		BeforeEach(func() {
-			name = "foo"
-			dsl = func() {
-				apidsl.Status(status)
-				apidsl.Media(mediaType)
-			}
-		})
-
-		It("sets the status and media type", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Validate()).ShouldNot(HaveOccurred())
-			Ω(res.Status).Should(Equal(status))
-			Ω(res.MediaType).Should(Equal(mediaType))
-		})
-	})
-
-	Context("with a status and headers", func() {
-		const status = 201
-		const headerName = "Location"
-
-		BeforeEach(func() {
-			name = "foo"
-			dsl = func() {
-				apidsl.Status(status)
-				apidsl.Headers(func() {
-					apidsl.Header(headerName)
+	t.Run("with a status", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("foo", func() {
+					apidsl.Status(201)
 				})
-			}
+			})
 		})
+		_ = dslengine.Run()
 
-		It("sets the status and headers", func() {
-			Ω(res).ShouldNot(BeNil())
-			Ω(res.Validate()).ShouldNot(HaveOccurred())
-			Ω(res.Status).Should(Equal(status))
-			Ω(res.Headers).ShouldNot(BeNil())
-			Ω(res.Headers.Type).Should(BeAssignableToTypeOf(design.Object{}))
-			o := res.Headers.Type.(design.Object)
-			Ω(o).Should(HaveLen(1))
-			Ω(o).Should(HaveKey(headerName))
-		})
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if err := res.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+		if res.Status != 201 {
+			t.Errorf("Status = %d; want 201", res.Status)
+		}
+		if res.Parent == nil {
+			t.Error("Parent = nil; want not nil")
+		}
 	})
 
-	Context("not from the shogoa default definitions", func() {
-		BeforeEach(func() {
-			name = "foo"
+	t.Run("with a type override", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				dt := apidsl.HashOf(design.String, design.Any)
+				apidsl.Response("foo", dt, func() {
+					apidsl.Status(201)
+				})
+			})
 		})
+		_ = dslengine.Run()
 
-		It("does not set the Standard flag", func() {
-			Ω(res.Standard).Should(BeFalse())
-		})
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if err := res.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+		if res.Status != 201 {
+			t.Errorf("Status = %d; want 201", res.Status)
+		}
+		if res.Type == nil {
+			t.Error("Type = nil; want not nil")
+		}
 	})
 
-	Context("from the shogoa default definitions", func() {
-		BeforeEach(func() {
-			name = "Created"
+	t.Run("with a status and description", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("foo", func() {
+					apidsl.Status(201)
+					apidsl.Description("desc")
+				})
+			})
 		})
+		_ = dslengine.Run()
 
-		It("sets the Standard flag", func() {
-			Ω(res.Standard).Should(BeTrue())
-		})
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if err := res.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+		if res.Status != 201 {
+			t.Errorf("Status = %d; want 201", res.Status)
+		}
+		if res.Description != "desc" {
+			t.Errorf("Description = %q; want %q", res.Description, "desc")
+		}
 	})
 
-})
+	t.Run("with a status and name override", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("foo", func() {
+					apidsl.Status(201)
+				})
+			})
+		})
+		_ = dslengine.Run()
+
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if err := res.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+		if res.Status != 201 {
+			t.Errorf("Status = %d; want 201", res.Status)
+		}
+	})
+
+	t.Run("with a status and media type", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("foo", func() {
+					apidsl.Status(201)
+					apidsl.Media("mt")
+				})
+			})
+		})
+		_ = dslengine.Run()
+
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if err := res.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+		if res.Status != 201 {
+			t.Errorf("Status = %d; want 201", res.Status)
+		}
+		if res.MediaType != "mt" {
+			t.Errorf("MediaType = %q; want %q", res.MediaType, "mt")
+		}
+	})
+
+	t.Run("with a status and headers", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("foo", func() {
+					apidsl.Status(201)
+					apidsl.Headers(func() {
+						apidsl.Header("Location")
+					})
+				})
+			})
+		})
+		_ = dslengine.Run()
+
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if err := res.Validate(); err != nil {
+			t.Errorf("Validate() = %v; want nil", err)
+		}
+		if res.Status != 201 {
+			t.Errorf("Status = %d; want 201", res.Status)
+		}
+		if res.Headers == nil {
+			t.Error("Headers = nil; want not nil")
+		}
+	})
+
+	t.Run("not from the shogoa default definitions", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("foo")
+			})
+		})
+		_ = dslengine.Run()
+
+		res := design.Design.Resources["res"].Actions["action"].Responses["foo"]
+		if res.Standard {
+			t.Error("Standard = true; want false")
+		}
+	})
+
+	t.Run("from the shogoa default definitions", func(t *testing.T) {
+		dslengine.Reset()
+		apidsl.Resource("res", func() {
+			apidsl.Action("action", func() {
+				apidsl.Response("Created")
+			})
+		})
+		_ = dslengine.Run()
+
+		res := design.Design.Resources["res"].Actions["action"].Responses["Created"]
+		if !res.Standard {
+			t.Error("Standard = false; want true")
+		}
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Transitioned from Ginkgo testing framework to standard Go testing framework for improved organization and readability.
	- Updated test structure to encapsulate cases within `t.Run` calls, ensuring isolation and clarity.
	- Adjusted assertion methods to align with Go's native testing practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->