### PR TITLE
bump Go 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - "macos-latest"
         go:
           - "stable"
-          - "1.22"
+          - "1.23"
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/shogoa
 
-go 1.22.5
+go 1.23.0
 
 require (
 	github.com/ajg/form v1.5.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Go version from 1.22 to 1.23 in the workflow configuration and module file.
	- Corrected formatting in the workflow configuration for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->