### PR TITLE
refactor shogoagen/codegen/helpers_test.go

### DIFF
--- a/shogoagen/codegen/helpers_test.go
+++ b/shogoagen/codegen/helpers_test.go
@@ -1,94 +1,137 @@
 package codegen_test
 
 import (
-	"fmt"
-	"go/build"
 	"os"
 	"path/filepath"
 	"runtime"
+	"testing"
 
 	"github.com/shogo82148/shogoa/shogoagen/codegen"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Helpers", func() {
-	Describe("KebabCase", func() {
-		It("should change uppercase letters to lowercase letters", func() {
-			Expect(codegen.KebabCase("test-B")).To(Equal("test-b"))
-			Expect(codegen.KebabCase("teste")).To(Equal("teste"))
+func TestKebabCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// should change uppercase letters to lowercase letters
+		{
+			input: "test-B",
+			want:  "test-b",
+		},
+		{
+			input: "teste",
+			want:  "teste",
+		},
+
+		// should not add a dash before an abbreviation or acronym
+		{
+			input: "testABC",
+			want:  "testabc",
+		},
+
+		// should add a dash before a title
+		{
+			input: "testAa",
+			want:  "test-aa",
+		},
+		{
+			input: "testAbc",
+			want:  "test-abc",
+		},
+
+		// should replace underscores to dashes
+		{
+			input: "test_cA",
+			want:  "test-ca",
+		},
+		{
+			input: "test_D",
+			want:  "test-d",
+		},
+	}
+
+	for _, tt := range tests {
+		if got := codegen.KebabCase(tt.input); got != tt.want {
+			t.Errorf("KebabCase(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCommandLine(t *testing.T) {
+	t.Run("with exported GOPATH", func(t *testing.T) {
+		t.Setenv("GOPATH", "/xx")
+		oldArgs := os.Args
+		t.Cleanup(func() {
+			os.Args = oldArgs
 		})
 
-		It("should not add a dash before an abbreviation or acronym", func() {
-			Expect(codegen.KebabCase("testABC")).To(Equal("testabc"))
-		})
+		tests := []struct {
+			name string
+			args []string
+			want string
+		}{
+			{
+				name: "should not touch free arguments",
+				args: []string{"foo", "/xx/bar/xx/42"},
+				want: "$ foo /xx/bar/xx/42",
+			},
+			{
+				name: "should replace GOPATH one match only in a long option",
+				args: []string{"foo", "--opt=/xx/bar/xx/42"},
+				want: "$ foo\n\t--opt=$(GOPATH)/bar/xx/42",
+			},
+			{
+				name: "should not replace GOPATH if a match is not at the beginning of a long option",
+				args: []string{"foo", "--opt=/bar/xx/42"},
+				want: "$ foo\n\t--opt=/bar/xx/42",
+			},
+		}
 
-		It("should add a dash before a title", func() {
-			Expect(codegen.KebabCase("testAa")).To(Equal("test-aa"))
-			Expect(codegen.KebabCase("testAbc")).To(Equal("test-abc"))
-		})
-
-		It("should replace underscores to dashes", func() {
-			Expect(codegen.KebabCase("test_cA")).To(Equal("test-ca"))
-			Expect(codegen.KebabCase("test_D")).To(Equal("test-d"))
-		})
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				os.Args = tt.args
+				if got := codegen.CommandLine(); got != tt.want {
+					t.Errorf("CommandLine() = %q, want %q", got, tt.want)
+				}
+			})
+		}
 	})
 
-	Describe("CommandLine", func() {
-		Context("with exported GOPATH", func() {
-			oldGOPATH, oldArgs := build.Default.GOPATH, os.Args
-			BeforeEach(func() {
-				os.Setenv("GOPATH", "/xx")
-			})
-			AfterEach(func() {
-				os.Setenv("GOPATH", oldGOPATH)
-				os.Args = oldArgs
-			})
-
-			It("should not touch free arguments", func() {
-				os.Args = []string{"foo", "/xx/bar/xx/42"}
-
-				Expect(codegen.CommandLine()).To(Equal("$ foo /xx/bar/xx/42"))
-			})
-
-			It("should replace GOPATH one match only in a long option", func() {
-				os.Args = []string{"foo", "--opt=/xx/bar/xx/42"}
-
-				Expect(codegen.CommandLine()).To(Equal("$ foo\n\t--opt=$(GOPATH)/bar/xx/42"))
-			})
-
-			It("should not replace GOPATH if a match is not at the beginning of a long option", func() {
-				os.Args = []string{"foo", "--opt=/bar/xx/42"}
-
-				Expect(codegen.CommandLine()).To(Equal("$ foo\n\t--opt=/bar/xx/42"))
-			})
+	t.Run("with default GOPATH", func(t *testing.T) {
+		t.Setenv("GOPATH", defaultGOPATH()) // Simulate a situation with no GOPATH exported.
+		oldArgs := os.Args
+		t.Cleanup(func() {
+			os.Args = oldArgs
 		})
 
-		Context("with default GOPATH", func() {
-			oldGOPATH, oldArgs := build.Default.GOPATH, os.Args
-			BeforeEach(func() {
-				os.Setenv("GOPATH", defaultGOPATH()) // Simulate a situation with no GOPATH exported.
-			})
-			AfterEach(func() {
-				os.Setenv("GOPATH", oldGOPATH)
-				os.Args = oldArgs
-			})
+		tests := []struct {
+			name string
+			args []string
+			want string
+		}{
+			{
+				name: "should not touch free arguments",
+				args: []string{"foo", "/xx/bar/xx/42"},
+				want: "$ foo /xx/bar/xx/42",
+			},
+			{
+				name: "should replace GOPATH one match only in a long option",
+				args: []string{"foo", "--opt=" + defaultGOPATH() + "/bar/xx/42"},
+				want: "$ foo\n\t--opt=$(GOPATH)/bar/xx/42",
+			},
+		}
 
-			It("should not touch free arguments", func() {
-				os.Args = []string{"foo", "/xx/bar/xx/42"}
-
-				Expect(codegen.CommandLine()).To(Equal("$ foo /xx/bar/xx/42"))
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				os.Args = tt.args
+				if got := codegen.CommandLine(); got != tt.want {
+					t.Errorf("CommandLine() = %q, want %q", got, tt.want)
+				}
 			})
-
-			It("should replace GOPATH one match only in a long option", func() {
-				os.Args = []string{"foo", fmt.Sprintf("--opt=%s/bar/xx/42", defaultGOPATH())}
-
-				Expect(codegen.CommandLine()).To(Equal("$ foo\n\t--opt=$(GOPATH)/bar/xx/42"))
-			})
-		})
+		}
 	})
-})
+}
 
 // Copied from go/build/build.go
 func defaultGOPATH() string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of tests by transitioning from the Ginkgo framework to the standard Go testing framework.
  
- **Refactor**
	- Restructured tests for `KebabCase` and `CommandLine` functions to utilize table-driven testing, enhancing organization and clarity. 

- **Chores**
	- Updated import statements to remove unnecessary dependencies and ensure proper cleanup of environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->